### PR TITLE
Dsiplay Mode & Timezones

### DIFF
--- a/FluentUIMonthPicker/ControlManifest.Input.xml
+++ b/FluentUIMonthPicker/ControlManifest.Input.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <manifest>
-  <control namespace="DR" constructor="FluentUIMonthPicker" version="0.0.15" display-name-key="FluentUIMonthPicker" description-key="FluentUIMonthPicker description" control-type="standard" >
+  <control namespace="DR" constructor="FluentUIMonthPicker" version="0.0.17" display-name-key="FluentUIMonthPicker" description-key="FluentUIMonthPicker description" control-type="standard" >
     
     <external-service-usage enabled="false">
     </external-service-usage>

--- a/FluentUIMonthPicker/MonthPickerApp.tsx
+++ b/FluentUIMonthPicker/MonthPickerApp.tsx
@@ -17,6 +17,7 @@ export const useStyles = makeStyles({
 export interface IMonthPickerProps {
     instanceId: string
     dateValue: Date | undefined
+    dateBehavior: 'userLocal' | 'timezoneIndependent' | 'dateOnly' | undefined;
     minDateValue: Date | undefined
     maxDateValue: Date | undefined
     monthDisplayFormat: Intl.DateTimeFormatOptions["month"]
@@ -54,9 +55,15 @@ const MonthPickerApp = (props:IMonthPickerProps): JSX.Element => {
       if (props.dateValue === undefined) {
         return props.dateValue;
       }
+
+      let newDateTime = props.dateValue.getTime();
+
+      // Adjust by the timezone offset
+      if(props.dateBehavior === 'userLocal') {
+        newDateTime += timezoneOffsetMilliseconds;
+      }
       
-      // Create a new date object that is adjusted by the timezone offset
-      return new Date(props.dateValue.getTime() + timezoneOffsetMilliseconds);
+      return new Date(newDateTime);
     });
 
     const inputRef = useRef<HTMLInputElement>(null);
@@ -131,8 +138,8 @@ const MonthPickerApp = (props:IMonthPickerProps): JSX.Element => {
                 highlightSelectedMonth
                 isDayPickerVisible={false}
                 onSelectDate={onSelectMonth}
-                minDate={props.minDateValue ? new Date(props.minDateValue.getTime() + timezoneOffsetMilliseconds) : undefined}
-                maxDate={props.maxDateValue ? new Date(props.maxDateValue.getTime() + timezoneOffsetMilliseconds) : undefined}
+                minDate={props.minDateValue ? new Date(props.minDateValue.getTime() + (props.dateBehavior === 'userLocal' ? timezoneOffsetMilliseconds : 0)) : undefined}
+                maxDate={props.maxDateValue ? new Date(props.maxDateValue.getTime() + (props.dateBehavior === 'userLocal' ? timezoneOffsetMilliseconds : 0)) : undefined}
                 value={selectedDate}
               />
             </PopoverSurface>

--- a/FluentUIMonthPicker/MonthPickerApp.tsx
+++ b/FluentUIMonthPicker/MonthPickerApp.tsx
@@ -106,7 +106,7 @@ const MonthPickerApp = (props:IMonthPickerProps): JSX.Element => {
         
       <IdPrefixProvider value={`month-picker-${props.instanceId}-`}>
         <FluentProvider theme={props.isDarkMode ? webDarkTheme : webLightTheme} >
-          <Popover positioning={{ positioningRef }} open={open} onOpenChange={handleOpenChange}>
+          <Popover positioning={{ positioningRef }} open={props.disabled ? false : open} onOpenChange={handleOpenChange}>
             <PopoverTrigger disableButtonEnhancement>
               <Input
                   className={styles.root}

--- a/FluentUIMonthPicker/index.ts
+++ b/FluentUIMonthPicker/index.ts
@@ -19,6 +19,7 @@ export class FluentUIMonthPicker implements ComponentFramework.StandardControl<I
     private _props: IMonthPickerProps = {
         instanceId: uuidv4(),
         dateValue: undefined,
+        dateBehavior: undefined,
         minDateValue: undefined,
         maxDateValue: undefined,
         isDarkMode: false,
@@ -119,6 +120,23 @@ export class FluentUIMonthPicker implements ComponentFramework.StandardControl<I
             default:
                 this._props.yearDisplayFormat = "numeric";
                 break;
+        }
+
+        switch (context.parameters.startDate.attributes?.Behavior) {
+            case 1:
+                this._props.dateBehavior = "userLocal";
+                break;
+            case 2:
+                this._props.dateBehavior = "dateOnly";
+                break;
+            case 3:
+                this._props.dateBehavior = "timezoneIndependent";
+                break;
+                
+                
+            default:
+                this._props.dateBehavior = "dateOnly";
+                break;    
         }
 
         this._props.localeDisplayFormat = (context.userSettings as any).locale ?? "fr-CA";

--- a/Solution/src/Other/Solution.xml
+++ b/Solution/src/Other/Solution.xml
@@ -2,25 +2,25 @@
 <ImportExportXml version="9.1.0.643" SolutionPackageVersion="9.1" languagecode="1033" generatedBy="CrmLive" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <SolutionManifest>
     <!-- Unique Name of Cds Solution-->
-    <UniqueName>Solution</UniqueName>
+    <UniqueName>FluentUIMonthPickerPCF</UniqueName>
     <LocalizedNames>
       <!-- Localized Solution Name in language code -->
-      <LocalizedName description="Solution" languagecode="1033" />
+      <LocalizedName description="FluentUI.MonthPicker.PCF" languagecode="1033" />
     </LocalizedNames>
     <Descriptions />
-    <Version>1.0</Version>
+    <Version>1.0.3</Version>
     <!-- Solution Package Type: Unmanaged(0)/Managed(1)/Both(2)-->
     <Managed>2</Managed>
     <Publisher>
       <!-- Unique Publisher Name of Cds Solution -->
-      <UniqueName>drivardxrm</UniqueName>
+      <UniqueName>driv</UniqueName>
       <LocalizedNames>
         <!-- Localized Cds Publisher Name in language code-->
-        <LocalizedName description="drivardxrm" languagecode="1033" />
+        <LocalizedName description="driv" languagecode="1033" />
       </LocalizedNames>
       <Descriptions>
         <!-- Description of Cds Publisher in language code -->
-        <Description description="drivardxrm" languagecode="1033" />
+        <Description description="driv" languagecode="1033" />
       </Descriptions>
       <EMailAddress xsi:nil="true"></EMailAddress>
       <SupportingWebsiteUrl xsi:nil="true"></SupportingWebsiteUrl>


### PR DESCRIPTION
The changes in the pull request should solve two issues:
- Timezone adjustment - for date only columns with date only timezone settings and Central European Summer Time timezone the timezone adjustment moved the date to previous day 23:00 -> timezone adjustment is now avoided altogether if the bound column does not include timezone logic
- Display Mode - when the component was marked as read only / disabled, the date icon could still be clicked to display the calendar aria popover and the user was normally allowed to edit the date -> now the calendar popover is never displayed if the component is disabled, therefore, user cannot change the date